### PR TITLE
MAKVONotificationCenter: Explicitly cast to avoid warning.

### DIFF
--- a/MAKVONotificationCenter.m
+++ b/MAKVONotificationCenter.m
@@ -93,7 +93,8 @@ static char MAKVONotificationHelperMagicContext = 0;
         _options = options;
         
         // Pass only Apple's options to Apple's code.
-        options &= ~(MAKeyValueObservingOptionUnregisterManually);
+        options = (NSKeyValueObservingOptions)(options &
+                                               ~(MAKeyValueObservingOptionUnregisterManually));
         
         for (NSString *keyPath in _keyPaths)
         {


### PR DESCRIPTION
This commit updates a line in `MAKVONotificationCenter` by explicitly casting in order to avoid a warning.